### PR TITLE
Added playwright tests for undo redo behaviour

### DIFF
--- a/tests/blink_example.spec.ts
+++ b/tests/blink_example.spec.ts
@@ -1,6 +1,6 @@
 import consumers from "node:stream/consumers";
 import { expect, test } from "@playwright/test";
-import { goToHomePage } from "./utils";
+import { goToHomePage, openExample } from "./utils";
 
 test.beforeEach(goToHomePage);
 
@@ -8,10 +8,7 @@ test("Load Blink example and check code", async ({ page }) => {
 	await page.getByText("Leaphy Original").click();
 	await page.getByText("Original Uno").click();
 
-	// Open the blink example
-	await page.getByRole("button", { name: "My projects" }).click();
-	await page.getByRole("cell", { name: "Examples" }).click();
-	await page.getByRole("button", { name: "Blink" }).click();
+	await openExample(page, "blink");
 
 	await page.locator(".side").first().click(); // Open code
 

--- a/tests/undo_redo.spec.ts
+++ b/tests/undo_redo.spec.ts
@@ -31,29 +31,29 @@ test("Undo redo - Variable change", async ({ page }) => {
 	await loadExample(page, "blink");
 
 	// Change a boolean
-	await page.getByText('true').click();
-	await page.locator('#blockly-1').getByText('false').click();
-	await expect(page.getByText('false')).toHaveCount(2);
+	await page.getByText("true").click();
+	await page.locator("#blockly-1").getByText("false").click();
+	await expect(page.getByText("false")).toHaveCount(2);
 	await page.keyboard.press("Control+z");
-	await expect(page.getByText('false')).toHaveCount(1);
+	await expect(page.getByText("false")).toHaveCount(1);
 	await page.keyboard.press("Control+y");
-	await expect(page.getByText('false')).toHaveCount(2);
+	await expect(page.getByText("false")).toHaveCount(2);
 
 	// Change one of the delays
-	await page.getByText('1000').first().click();
-	await page.getByRole('textbox').fill('123');
-	await expect(page.getByText('123', { exact: true })).toBeVisible();
+	await page.getByText("1000").first().click();
+	await page.getByRole("textbox").fill("123");
+	await expect(page.getByText("123", { exact: true })).toBeVisible();
 	await page.keyboard.press("Control+z");
-	await expect(page.getByText('123', { exact: true })).toBeHidden();
+	await expect(page.getByText("123", { exact: true })).toBeHidden();
 	await page.keyboard.press("Control+y");
-	await expect(page.getByText('123', { exact: true })).toBeVisible();
-	
-	await page.getByRole('textbox').press('Enter');
-	await expect(page.getByText('123', { exact: true })).toBeVisible();
+	await expect(page.getByText("123", { exact: true })).toBeVisible();
+
+	await page.getByRole("textbox").press("Enter");
+	await expect(page.getByText("123", { exact: true })).toBeVisible();
 	await page.keyboard.press("Control+z");
-	await expect(page.getByText('123', { exact: true })).toBeHidden();
+	await expect(page.getByText("123", { exact: true })).toBeHidden();
 	await page.keyboard.press("Control+y");
-	await expect(page.getByText('123', { exact: true })).toBeVisible();
+	await expect(page.getByText("123", { exact: true })).toBeVisible();
 });
 
 test("Undo redo - Dragging", async ({ page }) => {
@@ -65,13 +65,15 @@ test("Undo redo - Dragging", async ({ page }) => {
 	await page.locator(".side").first().click(); // Open code
 
 	// Drag the repeat block somewhere to the left, disconnecting it
-	await page.getByText('repeat forever').dragTo(page.getByText('repeat forever'), {
-		force: true,
-		targetPosition: {
-			x: -250,
-			y: 0,
-		}
-	});
+	await page
+		.getByText("repeat forever")
+		.dragTo(page.getByText("repeat forever"), {
+			force: true,
+			targetPosition: {
+				x: -250,
+				y: 0,
+			},
+		});
 
 	await expect(page.locator(".view-lines")).not.toContainText("delay");
 
@@ -81,13 +83,15 @@ test("Undo redo - Dragging", async ({ page }) => {
 	await expect(page.locator(".view-lines")).not.toContainText("delay");
 
 	// Move it back to its original location, connecting it again
-	await page.getByText('repeat forever').dragTo(page.getByText('Leaphy', { exact: true }), {
-		force: true,
-		targetPosition: {
-			x: 0,
-			y: 50,
-		}
-	});
+	await page
+		.getByText("repeat forever")
+		.dragTo(page.getByText("Leaphy", { exact: true }), {
+			force: true,
+			targetPosition: {
+				x: 0,
+				y: 50,
+			},
+		});
 
 	await expect(page.locator(".view-lines")).toContainText("delay");
 	await page.keyboard.press("Control+z");

--- a/tests/undo_redo.spec.ts
+++ b/tests/undo_redo.spec.ts
@@ -55,3 +55,47 @@ test("Undo redo - Variable change", async ({ page }) => {
 	await page.keyboard.press("Control+y");
 	await expect(page.getByText('123', { exact: true })).toBeVisible();
 });
+
+test("Undo redo - Dragging", async ({ page }) => {
+	await page.getByText("Leaphy Original").click();
+	await page.getByText("Original Uno").click();
+
+	await loadExample(page, "blink");
+
+	await page.locator(".side").first().click(); // Open code
+
+	// Drag the repeat block somewhere to the left, disconnecting it
+	await page.getByText('repeat forever').dragTo(page.getByText('repeat forever'), {
+		force: true,
+		targetPosition: {
+			x: -250,
+			y: 0,
+		}
+	});
+
+	await expect(page.locator(".view-lines")).not.toContainText("delay");
+
+	await page.keyboard.press("Control+z");
+	await expect(page.locator(".view-lines")).toContainText("delay");
+	await page.keyboard.press("Control+y");
+	await expect(page.locator(".view-lines")).not.toContainText("delay");
+
+	// Move it back to its original location, connecting it again
+	await page.getByText('repeat forever').dragTo(page.getByText('Leaphy', { exact: true }), {
+		force: true,
+		targetPosition: {
+			x: 0,
+			y: 50,
+		}
+	});
+
+	await expect(page.locator(".view-lines")).toContainText("delay");
+	await page.keyboard.press("Control+z");
+	await expect(page.locator(".view-lines")).not.toContainText("delay");
+	await page.keyboard.press("Control+y");
+	await expect(page.locator(".view-lines")).toContainText("delay");
+	await page.keyboard.press("Control+z");
+	await expect(page.locator(".view-lines")).not.toContainText("delay");
+	await page.keyboard.press("Control+z");
+	await expect(page.locator(".view-lines")).toContainText("delay");
+});

--- a/tests/undo_redo.spec.ts
+++ b/tests/undo_redo.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { goToHomePage, openExample as loadExample } from "./utils";
+
+test.beforeEach(goToHomePage);
+
+test("Undo redo - Deletion", async ({ page }) => {
+	await page.getByText("Leaphy Original").click();
+	await page.getByText("Original Uno").click();
+
+	await loadExample(page, "blink");
+
+	// Delete the repeat forever block
+	await page.getByText("repeat forever").click();
+	await page.locator("svg").filter({ hasText: "Leaphy" }).press("Delete");
+	await expect(page.getByText("repeat forever")).toBeHidden();
+
+	await page.locator("div:nth-child(2) > button").first().click(); // Click undo button
+	await expect(page.getByText("repeat forever")).toBeVisible();
+	await page.locator("div:nth-child(2) > button:nth-child(2)").click(); // Click redo button
+	await expect(page.getByText("repeat forever")).toBeHidden();
+	await page.keyboard.press("Control+z");
+	await expect(page.getByText("repeat forever")).toBeVisible();
+	await page.keyboard.press("Control+y");
+	await expect(page.getByText("repeat forever")).toBeHidden();
+});
+
+test("Undo redo - Variable change", async ({ page }) => {
+	await page.getByText("Leaphy Original").click();
+	await page.getByText("Original Uno").click();
+
+	await loadExample(page, "blink");
+
+	// Change a boolean
+	await page.getByText('true').click();
+	await page.locator('#blockly-1').getByText('false').click();
+	await expect(page.getByText('false')).toHaveCount(2);
+	await page.keyboard.press("Control+z");
+	await expect(page.getByText('false')).toHaveCount(1);
+	await page.keyboard.press("Control+y");
+	await expect(page.getByText('false')).toHaveCount(2);
+
+	// Change one of the delays
+	await page.getByText('1000').first().click();
+	await page.getByRole('textbox').fill('123');
+	await expect(page.getByText('123', { exact: true })).toBeVisible();
+	await page.keyboard.press("Control+z");
+	await expect(page.getByText('123', { exact: true })).toBeHidden();
+	await page.keyboard.press("Control+y");
+	await expect(page.getByText('123', { exact: true })).toBeVisible();
+	
+	await page.getByRole('textbox').press('Enter');
+	await expect(page.getByText('123', { exact: true })).toBeVisible();
+	await page.keyboard.press("Control+z");
+	await expect(page.getByText('123', { exact: true })).toBeHidden();
+	await page.keyboard.press("Control+y");
+	await expect(page.getByText('123', { exact: true })).toBeVisible();
+});

--- a/tests/undo_redo.spec.ts
+++ b/tests/undo_redo.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { goToHomePage, openExample as loadExample } from "./utils";
 
 test.beforeEach(goToHomePage);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,7 +1,13 @@
-import type { PlaywrightTestArgs } from "@playwright/test";
+import type { Page, PlaywrightTestArgs } from "@playwright/test";
 
 export async function goToHomePage({ page }: PlaywrightTestArgs) {
 	await page.goto("/");
 	await page.getByRole("button", { name: "English" }).click();
 	await page.getByRole("button", { name: "Let's get started!" }).click();
+}
+
+export async function openExample(page: Page, example: string | RegExp) {
+	await page.getByRole("button", { name: "My projects" }).click();
+	await page.getByRole("cell", { name: "Examples" }).click();
+	await page.getByRole("button", { name: example }).click();
 }


### PR DESCRIPTION
This adds 3 tests to check if undo/redo works correctly in the blockly editor