### PR TITLE
fix: Feedback popup switched email and name in the form bindings

### DIFF
--- a/src/lib/components/core/popups/popups/Feedback.svelte
+++ b/src/lib/components/core/popups/popups/Feedback.svelte
@@ -52,7 +52,7 @@ function onsubmit(event: SubmitEvent) {
 	<div class="input">
 		<TextInput
 			placeholder={$_("NAME")}
-			bind:value={senderEmail}
+			bind:value={senderName}
 			mode="secondary"
 			focus={true}
 			required
@@ -63,7 +63,7 @@ function onsubmit(event: SubmitEvent) {
 	<div class="input">
 		<TextInput
 			placeholder={$_("EMAIL")}
-			bind:value={senderName}
+			bind:value={senderEmail}
 			mode="secondary"
 			type="email"
 			required


### PR DESCRIPTION
The Feedback form was binding the Name as the Email, and the Email as the Name
This PR makes it so that they are now correctly bound