### PR TITLE
test: Made arduino tests faster & included more logging

### DIFF
--- a/tests/arduino.spec.ts
+++ b/tests/arduino.spec.ts
@@ -43,6 +43,7 @@ test("Arduino - C++ upload", async ({ page }) => {
 
 // Help debug errors in the above tests
 test.afterEach(async ({ page }) => {
-	let log = await page.evaluate("window.avrdudeLog");
-	console.log(JSON.stringify(log, null, 4));
+	await page.evaluate(
+		"console.log(JSON.stringify(window.avrdudeLog, null, 4))",
+	);
 });

--- a/tests/arduino.spec.ts
+++ b/tests/arduino.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { goToHomePage, openExample, setupArduino } from "./utils";
 
+test.describe.configure({ mode: "serial" });
+
 test.beforeEach(setupArduino);
 test.beforeEach(goToHomePage);
 
@@ -12,12 +14,15 @@ test("Arduino - Blockly upload", async ({ page }) => {
 
 	await page.getByRole("button", { name: "Upload to robot" }).click();
 	await expect(
-		page.getByRole("heading", { name: "Robot update complete" }),
+		page.getByRole("button", { name: "Go back to editor" }),
 	).toBeVisible({
 		timeout: 15000,
 	});
-
-	await page.getByRole("button", { name: "Go back to editor" }).click();
+	await expect(
+		page.getByRole("heading", { name: "Robot update complete" }),
+	).toBeVisible({
+		timeout: 50, // It should already be visible
+	});
 });
 
 test("Arduino - C++ upload", async ({ page }) => {
@@ -25,10 +30,19 @@ test("Arduino - C++ upload", async ({ page }) => {
 
 	await page.getByRole("button", { name: "Upload to robot" }).click();
 	await expect(
-		page.getByRole("heading", { name: "Robot update complete" }),
+		page.getByRole("button", { name: "Go back to editor" }),
 	).toBeVisible({
 		timeout: 15000,
 	});
+	await expect(
+		page.getByRole("heading", { name: "Robot update complete" }),
+	).toBeVisible({
+		timeout: 50, // It should already be visible
+	});
+});
 
-	await page.getByRole("button", { name: "Go back to editor" }).click();
+// Help debug errors in the above tests
+test.afterEach(async ({ page }) => {
+	let log = await page.evaluate("window.avrdudeLog");
+	console.log(JSON.stringify(log, null, 4));
 });


### PR DESCRIPTION
This PR makes the Arduino tests faster by looking for "Go back to editor" instead of "Upload complete"
The effect of this is that the test run faster on failure, and is unchanged when it succeeds

It also adds logging of `window.avrdudeLog` at the end of each test to help debug it on failure

It also makes the tests run one by one as a experiment to see if this makes the test less flakey
The Github Action only uses one worker (because it has 1 thread) so it does not slow that down.