### PR TITLE
test: dragging block to trashcan should delete it

### DIFF
--- a/tests/undo_redo.spec.ts
+++ b/tests/undo_redo.spec.ts
@@ -30,6 +30,15 @@ test("Undo redo - Deletion", async ({ page }) => {
 	await expect(page.getByText("repeat forever")).toBeVisible();
 	await redo(page);
 	await expect(page.getByText("repeat forever")).toBeHidden();
+
+	await undo(page);
+	await expect(page.getByText("repeat forever")).toBeVisible();
+	await page
+		.getByText("repeat forever")
+		.dragTo(page.locator("g.blocklyTrash"), {
+			force: true,
+		});
+	await expect(page.getByText("repeat forever")).toBeHidden();
 });
 
 test("Undo redo - Variable change", async ({ page }) => {


### PR DESCRIPTION
Extends the Deletion Undo/Redo test to include dragging a block into the trashcan