### PR TITLE
test: added test for 'nederlands' language and fixed one field not getting renamed

### DIFF
--- a/src/lib/components/core/popups/popups/PythonUploader.svelte
+++ b/src/lib/components/core/popups/popups/PythonUploader.svelte
@@ -109,7 +109,7 @@ async function connectUSB() {
             {/if}
             {#if done}
                 <Button
-                    name={"Go back to editor"}
+                    name={$_("LEAVE_UPLOADING")}
                     mode={"primary"}
                     onclick={close}
                 />

--- a/src/lib/components/core/popups/popups/Uploader.svelte
+++ b/src/lib/components/core/popups/popups/Uploader.svelte
@@ -128,7 +128,7 @@ async function connectUSB() {
         {/if}
         {#if done}
             <Button
-                name={"Go back to editor"}
+				name={$_("LEAVE_UPLOADING")}
                 mode={"primary"}
                 onclick={close}
             />

--- a/tests/language.spec.ts
+++ b/tests/language.spec.ts
@@ -1,0 +1,34 @@
+import { type Page, expect, test } from "@playwright/test";
+import { goToHomePage, openExample } from "./utils";
+
+test.beforeEach(goToHomePage);
+
+test("Language", async ({ page }) => {
+	await page.getByRole("button", { name: "MicroPython MicroPython" }).click();
+	await page.getByRole("button", { name: "More..." }).click();
+	await page.getByRole('cell', { name: 'Language' }).click();
+	await page.getByRole("cell", { name: "Nederlands" }).click();
+	await page.getByRole("button", { name: "Mijn projecten" }).click();
+	await page.getByRole("cell", { name: "Nieuw" }).click();
+	await page.getByRole("button", { name: "Leaphy Original Leaphy" }).click();
+	await page
+		.getByRole("button", { name: "Original Nano ESP32 Original" })
+		.click();
+	await expect(page.getByText("Lees afstand")).toBeVisible();
+	await expect(page.getByText("Lees anapin")).toBeVisible();
+	await expect(page.getByText("Lees gas")).toBeVisible();
+	await expect(page.getByText("Lees luchtdruk")).toBeVisible();
+	await page.locator("#l_numbers").click();
+	await expect(page.getByText("willekeurig getal van")).toBeVisible();
+	await expect(page.getByText("niet")).toBeVisible();
+	await page.getByText("even", { exact: true }).click();
+	await page.getByText("priemgetal").click();
+	await page.getByRole("button", { name: "Opslaan" }).click();
+	await expect(page.getByPlaceholder("Geef een bestandsnaam")).toBeVisible();
+	await page.getByRole("button", { name: "Annuleer" }).click();
+
+	// Prevent it from opening a popup requesting the port, act as if nothing gets selected
+	await page.evaluate("navigator.serial.requestPort = function() {}")
+	await page.getByRole("button", { name: "Upload naar robot" }).click();
+	await page.getByRole('button', { name: 'Ga terug naar code scherm' }).click();
+});

--- a/tests/language.spec.ts
+++ b/tests/language.spec.ts
@@ -6,7 +6,7 @@ test.beforeEach(goToHomePage);
 test("Language", async ({ page }) => {
 	await page.getByRole("button", { name: "MicroPython MicroPython" }).click();
 	await page.getByRole("button", { name: "More..." }).click();
-	await page.getByRole('cell', { name: 'Language' }).click();
+	await page.getByRole("cell", { name: "Language" }).click();
 	await page.getByRole("cell", { name: "Nederlands" }).click();
 	await page.getByRole("button", { name: "Mijn projecten" }).click();
 	await page.getByRole("cell", { name: "Nieuw" }).click();
@@ -28,7 +28,7 @@ test("Language", async ({ page }) => {
 	await page.getByRole("button", { name: "Annuleer" }).click();
 
 	// Prevent it from opening a popup requesting the port, act as if nothing gets selected
-	await page.evaluate("navigator.serial.requestPort = function() {}")
+	await page.evaluate("navigator.serial.requestPort = function() {}");
 	await page.getByRole("button", { name: "Upload naar robot" }).click();
-	await page.getByRole('button', { name: 'Ga terug naar code scherm' }).click();
+	await page.getByRole("button", { name: "Ga terug naar code scherm" }).click();
 });


### PR DESCRIPTION
This PR adds a test going through various menu's and checking that all items have been renamed once 'Nederlands' is selected.
It also adds translation for the "Go back to editor" text after uploading