### PR TITLE
fix: Remove the `get distance` block as its duplicated

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@leaphy-robotics/avrdude-webassembly": "^1.6.1",
     "@leaphy-robotics/dfu-util-wasm": "^1.0.2",
-    "@leaphy-robotics/leaphy-blocks": "3.1.0",
+    "@leaphy-robotics/leaphy-blocks": "^3.1.1",
     "@leaphy-robotics/picotool-wasm": "1.0.3",
     "@leaphy-robotics/webusb-ftdi": "1.0.1",
     "@sentry/svelte": "8.0.0-beta.5",

--- a/src/lib/domain/blockly/toolbox.ts
+++ b/src/lib/domain/blockly/toolbox.ts
@@ -46,10 +46,6 @@ export default [
 			],
 			[
 				{
-					type: "leaphy_original_get_distance",
-					robots: [...robotGroups.L_ORIGINAL_ALL, ...robotGroups.L_NANO_ALL],
-				},
-				{
 					type: "digital_read",
 				},
 				{
@@ -59,6 +55,7 @@ export default [
 			[
 				{
 					type: "leaphy_sonar_read",
+					fields: { TRIG_PIN: "8", ECHO_PIN: "7" },
 				},
 			],
 			[
@@ -76,10 +73,6 @@ export default [
 				},
 				{
 					type: "leaphy_i2c_rgb_color",
-				},
-				{
-					type: "leaphy_original_get_distance",
-					robots: [RobotType.L_CLICK],
 				},
 				{
 					type: "leaphy_tof_get_distance",

--- a/src/lib/examples/blink_distance.json
+++ b/src/lib/examples/blink_distance.json
@@ -36,8 +36,8 @@
 																"type": "leaphy_sonar_read",
 																"id": "u$GWvK~;BHT//.)aajeR",
 																"fields": {
-																"TRIG_PIN": "8",
-																"ECHO_PIN": "7"
+																	"TRIG_PIN": "8",
+																	"ECHO_PIN": "7"
 																}
 															}
 														},

--- a/src/lib/examples/blink_distance.json
+++ b/src/lib/examples/blink_distance.json
@@ -33,8 +33,12 @@
 																"fields": { "NUM": 1 }
 															},
 															"block": {
-																"type": "leaphy_original_get_distance",
-																"id": "-l]N2@hVF=BacXvt%kXU"
+																"type": "leaphy_sonar_read",
+																"id": "u$GWvK~;BHT//.)aajeR",
+																"fields": {
+																"TRIG_PIN": "8",
+																"ECHO_PIN": "7"
+																}
 															}
 														},
 														"B": {

--- a/src/lib/examples/distance.json
+++ b/src/lib/examples/distance.json
@@ -26,8 +26,12 @@
 													"fields": { "TEXT": "text" }
 												},
 												"block": {
-													"type": "leaphy_original_get_distance",
-													"id": "wjMq5+~Z[*Z(v=!a2_.T"
+													"type": "leaphy_sonar_read",
+													"id": "6.[a1G|zx+jJ#{X`Lc/J",
+													"fields": {
+													"TRIG_PIN": "8",
+													"ECHO_PIN": "7"
+													}
 												}
 											}
 										},

--- a/src/lib/examples/distance.json
+++ b/src/lib/examples/distance.json
@@ -29,8 +29,8 @@
 													"type": "leaphy_sonar_read",
 													"id": "6.[a1G|zx+jJ#{X`Lc/J",
 													"fields": {
-													"TRIG_PIN": "8",
-													"ECHO_PIN": "7"
+														"TRIG_PIN": "8",
+														"ECHO_PIN": "7"
 													}
 												}
 											}

--- a/tests/language.spec.ts
+++ b/tests/language.spec.ts
@@ -14,7 +14,7 @@ test("Language", async ({ page }) => {
 	await page
 		.getByRole("button", { name: "Original Nano ESP32 Original" })
 		.click();
-	await expect(page.getByText("Lees afstand")).toBeVisible();
+	await expect(page.getByText("Lees afstand")).not.toBeVisible(); // Should not be visible, the sonar trig block replaces it
 	await expect(page.getByText("Lees anapin")).toBeVisible();
 	await expect(page.getByText("Lees gas")).toBeVisible();
 	await expect(page.getByText("Lees luchtdruk")).toBeVisible();

--- a/tests/language.spec.ts
+++ b/tests/language.spec.ts
@@ -14,7 +14,7 @@ test("Language", async ({ page }) => {
 	await page
 		.getByRole("button", { name: "Original Nano ESP32 Original" })
 		.click();
-	await expect(page.getByText("Lees afstand")).not.toBeVisible(); // Should not be visible, the sonar trig block replaces it
+	await expect(page.getByText("Lees afstand")).toBeVisible();
 	await expect(page.getByText("Lees anapin")).toBeVisible();
 	await expect(page.getByText("Lees gas")).toBeVisible();
 	await expect(page.getByText("Lees luchtdruk")).toBeVisible();

--- a/yarn.lock
+++ b/yarn.lock
@@ -604,10 +604,10 @@
   resolved "https://registry.yarnpkg.com/@leaphy-robotics/dfu-util-wasm/-/dfu-util-wasm-1.0.2.tgz#29afcc01266655e1c7b5da0eeceb0ead48c86fd7"
   integrity sha512-lvS+tJFO049b4ERYKX0HcoUtnQv76A1z9sZrAvbs7s3bvdMW0BObKmktZeJ7emcp3lU/+OJWsD2h0EY5rnkiNg==
 
-"@leaphy-robotics/leaphy-blocks@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@leaphy-robotics/leaphy-blocks/-/leaphy-blocks-3.1.0.tgz#42402b9f76617c127607babc1945afa613e3ca06"
-  integrity sha512-FSyuY91gJKudltMHJlHfDHfz/VImAzKpn56bbbQrNra78EO+fatZGWsqqfcfI9TLpv0++vBvb6YyXmpTfkHRvQ==
+"@leaphy-robotics/leaphy-blocks@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@leaphy-robotics/leaphy-blocks/-/leaphy-blocks-3.1.1.tgz#7f83203b481a2dacbf9017ab8d7def15d9e80054"
+  integrity sha512-nbT/sY070Wgq+0RS6//q1s7MFR+2qhkh0z42+wm37ygTjw6s0o4Sm005gA/4DBiwiHI1azdtPwvKAlsFdAvfAg==
   dependencies:
     blockly "^10.4.3"
 


### PR DESCRIPTION
Removes the `get distance` block from the toolbox, while still having it exist so old projects remain working
The `Sonar trig` block has the same functionality but can specify what connections to use