### PR TITLE
Sleep block able to handle blocks as parameter value

### DIFF
--- a/packages/blocks/src/generators/python/situation.ts
+++ b/packages/blocks/src/generators/python/situation.ts
@@ -13,9 +13,9 @@ function getCodeGenerators(python: MicroPythonGenerator) {
 		//with a warning that some Micropython ports "may not accept [a] floating point argument
 		// [for the sleep function.]"
 
-		const delay = generator.valueToCode(block,"DELAY_TIME_MILI",Order.ATOMIC);
+		const delay = generator.valueToCode(block, "DELAY_TIME_MILI", Order.ATOMIC);
 
-		const delayMilis = Number.parseInt(delay,10);
+		const delayMilis = Number.parseInt(delay, 10);
 
 		if (Number.isNaN(delayMilis)) {
 			generator.addImport("utime", "sleep_ms");

--- a/packages/blocks/src/generators/python/situation.ts
+++ b/packages/blocks/src/generators/python/situation.ts
@@ -12,9 +12,15 @@ function getCodeGenerators(python: MicroPythonGenerator) {
 		//Said module offers both a sleep(seconds) function and a sleep_ms(ms) function, along
 		//with a warning that some Micropython ports "may not accept [a] floating point argument
 		// [for the sleep function.]"
-		const delayMilis = Number.parseInt(
-			generator.valueToCode(block, "DELAY_TIME_MILI", Order.ATOMIC),
-		);
+
+		const delay = generator.valueToCode(block,"DELAY_TIME_MILI",Order.ATOMIC);
+
+		const delayMilis = Number.parseInt(delay,10);
+
+		if (Number.isNaN(delayMilis)) {
+			generator.addImport("utime", "sleep_ms");
+			return `sleep(${delay})\n`;
+		}
 		if (delayMilis % 1000 === 0) {
 			//Whole seconds.
 			const delaySeconds = delayMilis / 1000;

--- a/packages/blocks/src/generators/python/situation.ts
+++ b/packages/blocks/src/generators/python/situation.ts
@@ -13,23 +13,11 @@ function getCodeGenerators(python: MicroPythonGenerator) {
 		//with a warning that some Micropython ports "may not accept [a] floating point argument
 		// [for the sleep function.]"
 
-		const delay = generator.valueToCode(block, "DELAY_TIME_MILI", Order.ATOMIC);
+		const delay = generator.valueToCode(block, "DELAY_TIME_MILI", Order.NONE);
 
-		const delayMilis = Number.parseInt(delay, 10);
-
-		if (Number.isNaN(delayMilis)) {
-			generator.addImport("utime", "sleep_ms");
-			return `sleep(${delay})\n`;
-		}
-		if (delayMilis % 1000 === 0) {
-			//Whole seconds.
-			const delaySeconds = delayMilis / 1000;
-			generator.addImport("utime", "sleep");
-			return `sleep(${delaySeconds})\n`;
-		}
-		//whole mililseconds.
 		generator.addImport("utime", "sleep_ms");
-		return `sleep_ms(${delayMilis})\n`;
+
+		return `sleep(${delay})\n`;
 	};
 
 	//The default python generator does not innately support infinite loops, surprisingly.


### PR DESCRIPTION
Fix for #233 

Initial implementation of `sleep_for` block did not account for non-number inputs; this has been remedied by checking if the convert-to-number operation failed.