### PR TITLE
I2C devices outside of a channel-select block default to broadcasting.

### DIFF
--- a/packages/blocks/src/generators/arduino/arduino.ts
+++ b/packages/blocks/src/generators/arduino/arduino.ts
@@ -75,7 +75,7 @@ function getCodeGenerators(arduino: Arduino) {
 		);
 		arduino.addDeclaration(
 			"leaphy_tof_read",
-			`int getTOF() {\n    ${setup}\n    VL53L0X_RangingMeasurementData_t measure;\n    i2c_distance.rangingTest(&measure, false);\n    if (measure.RangeStatus == 4) return -1;\n    return measure.RangeMilliMeter;\n}`,
+			`int getTOF() {\n    ${setup}\n    VL53L0X_RangingMeasurementData_t measure;\n    i2c_distance.rangingTest(&measure, false);\n    if (measure.RangeStatus == 4) return -1;\n    delay(33);\n    return measure.RangeMilliMeter;\n}`,
 		);
 		return ["getTOF()", arduino.ORDER_ATOMIC];
 	};

--- a/packages/blocks/src/generators/arduino/procedures.ts
+++ b/packages/blocks/src/generators/arduino/procedures.ts
@@ -61,11 +61,6 @@ function getCodeGenerators(arduino: Arduino) {
 			branch =
 				arduino.INFINITE_LOOP_TRAP.replace(/%1/g, `'${block.id}'`) + branch;
 		}
-		let returnValue =
-			arduino.valueToCode(block, "RETURN", arduino.ORDER_NONE) || "";
-		if (returnValue) {
-			returnValue = `  return ${returnValue};\n`;
-		}
 
 		// Get arguments with type
 		const args = [];
@@ -76,8 +71,9 @@ function getCodeGenerators(arduino: Arduino) {
 				Blockly.Names.NameType.VARIABLE,
 			)}`;
 		}
-		let returnType: string;
-		// Get return type
+		let returnType = "void";
+		let returnValue = "";
+		// Get return type and value
 		if (block.type === "procedures_defreturn") {
 			const checks = block
 				.getInput("RETURN")
@@ -85,8 +81,12 @@ function getCodeGenerators(arduino: Arduino) {
 
 			if (checks?.[0]) returnType = arduino.TYPES[checks[0]];
 			else returnType = "double";
-		} else {
-			returnType = "void";
+
+			returnValue =
+				arduino.valueToCode(block, "RETURN", arduino.ORDER_NONE) || "";
+			if (returnValue) {
+				returnValue = `  return ${returnValue};\n`;
+			}
 		}
 
 		// Construct code

--- a/packages/blocks/src/generators/python/sensors.ts
+++ b/packages/blocks/src/generators/python/sensors.ts
@@ -49,15 +49,13 @@ function getCodeGenerators(python: MicroPythonGenerator) {
 	};
 
 	python.forBlock.leaphy_tof_get_distance = (block, generator) => {
-		const active_channel = generator.currentI2cChannel() || "255";
-		const variable_name = generator.getVariableName(
-			`CHANNEL_${active_channel}_TOF`,
-		);
+		const active_channel = generator.currentI2cChannel() || "BC";
+		const variable_name = generator.getVariableName(`TOF_${active_channel}`);
 		generator.addI2cSupport(false);
 		generator.addImport("leaphymicropython.sensors.tof", "TimeOfFlight");
 		generator.addDefinition(
 			`channel${active_channel}obj`,
-			`${variable_name} = TimeOfFlight(${active_channel})\n${variable_name}.initialize_device()`,
+			`${variable_name} = TimeOfFlight(${active_channel === "BC" ? 255 : active_channel})\n${variable_name}.initialize_device()`,
 		);
 
 		generator.i2c_channel_clean_ = true;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,6 +48,7 @@
 		"chart.js": "^4.4.9",
 		"chartjs-adapter-date-fns": "^3.0.0",
 		"date-fns": "^4.1.0",
+		"dexie": "^4.0.11",
 		"esbuild": "^0.25.3",
 		"intel-hex": "^0.2.0",
 		"jszip": "^3.10.1",

--- a/packages/client/src/assets/translations/en.json
+++ b/packages/client/src/assets/translations/en.json
@@ -169,5 +169,11 @@
 	"AUTOGRADING_PASSED": "You did it!",
 	"AUTOGRADING_PASSED_DESC": "Congrats on completing the assignments sucessfully",
 	"AUTOGRADING_FAILED": "Oh no...",
-	"DONE_ASSIGNMENT": "Done"
+	"DONE_ASSIGNMENT": "Done",
+	"CONTINUE_WORKING": "Continue working",
+	"CONTINUE_WORKING_DESC": "Continue where you left off by selecting a recent project",
+	"LOCAL_SAVE": "Local save",
+	"TEMP_SAVE": "Temporary save",
+	"NO_INTERNET": "No internet, please check your connection",
+	"CHANGE_ROBOT": "Switch robot"
 }

--- a/packages/client/src/assets/translations/nl.json
+++ b/packages/client/src/assets/translations/nl.json
@@ -169,5 +169,11 @@
 	"AUTOGRADING_PASSED": "Gelukt!",
 	"AUTOGRADING_PASSED_DESC": "Gefeliciteerd met het sucessvol afronden van deze opdracht!",
 	"AUTOGRADING_FAILED": "Volgende keer beter...",
-	"DONE_ASSIGNMENT": "Ingeleverd"
+	"DONE_ASSIGNMENT": "Ingeleverd",
+	"CONTINUE_WORKING": "Ga door met bewerken",
+	"CONTINUE_WORKING_DESC": "Ga door waar je was gebleven door een recent project te selecteren",
+	"LOCAL_SAVE": "Lokaal opgeslagen",
+	"TEMP_SAVE": "Tijdelijk opgeslagen",
+	"NO_INTERNET": "Geen internetverbinding, controleer je verbinding",
+	"CHANGE_ROBOT": "Verander robot"
 }

--- a/packages/client/src/lib/components/core/popups/popups/Connect.svelte
+++ b/packages/client/src/lib/components/core/popups/popups/Connect.svelte
@@ -92,6 +92,7 @@ async function disabledSelect() {
 		BlocklyState.workspace,
 	);
 	WorkspaceState.handle = undefined;
+	WorkspaceState.handleSave = undefined;
 	return true;
 }
 </script>
@@ -101,7 +102,7 @@ async function disabledSelect() {
 	{#if categories.length > 1}
 		<ChipSelect options={categoriesFilter} bind:value={category} />
 	{/if}
-	<ListSelect {warning} options={values} {checkEnabled} disabledText={$_("INCOMPATIBLE_PROJECT")} {disabledSelect} bind:value={WorkspaceState.Mode} />
+	<ListSelect {warning} options={values} {checkEnabled} disabledText={$_("INCOMPATIBLE_PROJECT")} {disabledSelect} bind:value={WorkspaceState.robot} />
 	<Button onclick={start} mode="primary" name={$_("CONTINUE")} center bold />
 </div>
 

--- a/packages/client/src/lib/components/core/popups/popups/Restore.svelte
+++ b/packages/client/src/lib/components/core/popups/popups/Restore.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+import Button from "$components/ui/Button.svelte";
+import ListSelect from "$components/ui/ListSelect.svelte";
+import { robots } from "$domain/robots";
+import { type SavedContent, type SavedFile, projectDB } from "$domain/storage";
+import AppState, { Screen } from "$state/app.svelte";
+import BlocklyState from "$state/blockly.svelte";
+import type { PopupState } from "$state/popup.svelte";
+import RecordingState from "$state/recordings.svelte";
+import WorkspaceState, { Mode } from "$state/workspace.svelte";
+import { faCircleCheck, faXmark } from "@fortawesome/free-solid-svg-icons";
+import { getContext } from "svelte";
+import Fa from "svelte-fa";
+import { _ } from "svelte-i18n";
+import { Circle, DoubleBounce, RingLoader } from "svelte-loading-spinners";
+
+interface Props {
+	saves: ((SavedContent | SavedFile) & { type: string; saveID: number })[];
+}
+let { saves = $bindable() }: Props = $props();
+
+const popupState = getContext<PopupState>("state");
+let value = $state<SavedContent | SavedFile>(saves[0]);
+
+const saveOptions = $derived(
+	saves.map((save) => {
+		const robot = robots[save.robot];
+
+		let name = robot.name;
+		if (save.mode === "ADVANCED") {
+			name = `C++ - ${robot.name}`;
+		} else if (save.mode === "PYTHON") {
+			name = `MicroPython - ${robot.name}`;
+		}
+
+		if ("fileHandle" in save) {
+			name = `${save.fileHandle.name} (${name})`;
+		}
+
+		return [name, save];
+	}) as [string, SavedContent | SavedFile][],
+);
+
+function cancel() {
+	popupState.close();
+}
+
+async function open() {
+	if (!value) return;
+
+	WorkspaceState.robot = robots[value.robot];
+	WorkspaceState.Mode = Mode[value.mode];
+
+	if ("content" in value) {
+		if (value.mode === "BLOCKS") {
+			BlocklyState.restore = JSON.parse(value.content);
+		} else {
+			WorkspaceState.code = value.content;
+		}
+	} else {
+		await value.fileHandle.requestPermission();
+		await WorkspaceState.openFileHandle(value.fileHandle);
+	}
+
+	WorkspaceState.saveState = true;
+
+	AppState.Screen = Screen.WORKSPACE;
+	popupState.close();
+}
+
+async function deleteSave(
+	e: MouseEvent,
+	save: (SavedFile | SavedContent) & { type: string; saveID: number },
+) {
+	e.stopImmediatePropagation();
+
+	saves = saves.filter((e) => e.id !== save.id);
+	if ("content" in save) {
+		await projectDB.tempSaves.delete(save.saveID);
+	} else {
+		await projectDB.saves.delete(save.saveID);
+	}
+
+	if (saves.length === 0) popupState.close();
+}
+</script>
+
+<div class="content">
+	<div class="header">
+		<h1>{$_("CONTINUE_WORKING")}</h1>
+		<span>{$_("CONTINUE_WORKING_DESC")}</span>
+	</div>
+
+	<div class="test">
+		<ListSelect options={saveOptions} bind:value>
+			{#snippet render(name, save)}
+				{@const robot = robots[save.robot]}
+				<div class="save">
+					<div class="left">
+						<img src={robot.icon} alt={robot.name} class="icon">
+						<div class="detail">
+							<div class="name">{name}</div>
+							<div class="type">{'content' in save ? $_("TEMP_SAVE") : $_("LOCAL_SAVE")}</div>
+						</div>
+					</div>
+					<div onclick={(e) => deleteSave(e, save)} class="right">
+						<Fa icon={faXmark} />
+					</div>
+				</div>
+			{/snippet}
+		</ListSelect>
+	</div>
+
+	<div class="buttons">
+		<Button onclick={cancel} mode="secondary" large center name={$_("CANCEL")} />
+		<Button onclick={open} disabled={!value} large center mode="primary" name={$_("CONTINUE_WORKING")} />
+	</div>
+</div>
+
+<style>
+	.content {
+		padding: 20px;
+		display: flex;
+		flex-direction: column;
+		gap: 20px;
+		min-width: 500px;
+		text-align: center;
+	}
+
+	h1 {
+		margin: 0;
+	}
+
+	.header {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.test {
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+	}
+
+	span {
+		display: flex;
+		justify-content: center;
+		gap: 5px;
+	}
+
+	.save {
+		display: flex;
+		justify-content: space-between;
+		width: 100%;
+		align-items: center;
+		text-align: left;
+	}
+
+	.left {
+		display: flex;
+		gap: 10px;
+		align-items: center;
+	}
+
+	.right {
+		font-size: 24px;
+		color: salmon;
+		padding: 5px;
+		cursor: pointer;
+	}
+
+	.icon {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		height: 40px;
+		width: 40px;
+		object-fit: contain;
+	}
+
+	.detail {
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+	}
+
+	.name {
+		font-size: 18px;
+	}
+
+	.buttons {
+		display: flex;
+		justify-content: center;
+		gap: 10px;
+	}
+</style>

--- a/packages/client/src/lib/components/core/popups/popups/Uploader.svelte
+++ b/packages/client/src/lib/components/core/popups/popups/Uploader.svelte
@@ -39,24 +39,30 @@ class UploadError extends Error {
 
 async function compile() {
 	currentState = "COMPILATION_STARTED";
-	const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/compile/cpp`, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			source_code: source,
-			board: WorkspaceState.robot.fqbn,
-			libraries: [
-				...(WorkspaceState.Mode === Mode.ADVANCED
-					? [Dependencies.LEAPHY_EXTENSIONS]
-					: []),
-				...AppState.libraries.installed.map(
-					([name, version]) => `${name}@${version}`,
-				),
-			],
-		}),
-	});
+	let res: Response;
+	try {
+		res = await fetch(`${import.meta.env.VITE_BACKEND_URL}/compile/cpp`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				source_code: source,
+				board: WorkspaceState.robot.fqbn,
+				libraries: [
+					...(WorkspaceState.Mode === Mode.ADVANCED
+						? [Dependencies.LEAPHY_EXTENSIONS]
+						: []),
+					...AppState.libraries.installed.map(
+						([name, version]) => `${name}@${version}`,
+					),
+				],
+			}),
+		});
+	} catch (e) {
+		throw new UploadError("COMPILATION_FAILED", $_("NO_INTERNET"));
+	}
+
 	if (!res.ok) {
 		const { detail } = await res.json();
 		throw new UploadError("COMPILATION_FAILED", detail);

--- a/packages/client/src/lib/components/ui/ListSelect.svelte
+++ b/packages/client/src/lib/components/ui/ListSelect.svelte
@@ -4,11 +4,13 @@ import type { Snippet } from "svelte";
 interface Props<Type extends { id: string }> {
 	options: [string, Type][];
 	value: Type;
+
 	warning?: undefined | string;
 	checkEnabled?: (value: unknown) => boolean;
 	disabledText?: string;
 	disabled?: Snippet;
 	disabledSelect?: (value: unknown) => Promise<boolean>;
+	render?: Snippet<[string, Type, boolean]>;
 }
 let {
 	options,
@@ -18,6 +20,7 @@ let {
 	disabledText,
 	disabled,
 	disabledSelect,
+	render,
 }: Props<any> = $props();
 
 let reloadEnabled = $state(0);
@@ -43,8 +46,13 @@ async function onselect(option: unknown, enabled: boolean) {
 	{#key reloadEnabled}
 		{#each options as option}
 			{@const enabled = checkEnabled ? checkEnabled(option[1]) : true}
-			<button onclick={() => onselect(option[1], enabled)} class="item" class:selected={value.id === option[1].id}>
-				{option[0]}
+			<button onclick={() => onselect(option[1], enabled)} class="item" class:selected={value?.id === option[1].id}>
+				{#if render}
+					{@render render(option[0], option[1], value?.id === option[1].id)}
+				{:else}
+					{option[0]}
+				{/if}
+
 				{#if !enabled}
 					{#if disabled}
 						{@render disabled()}

--- a/packages/client/src/lib/domain/storage.ts
+++ b/packages/client/src/lib/domain/storage.ts
@@ -1,0 +1,26 @@
+import Dexie, { type EntityTable } from "dexie";
+
+interface BaseSave {
+	id: number;
+	mode: string;
+	robot: string;
+	date: number;
+}
+
+export interface SavedFile extends BaseSave {
+	fileHandle: FileSystemFileHandle;
+}
+
+export interface SavedContent extends BaseSave {
+	content: string;
+	fileSave?: number;
+}
+
+export const projectDB = new Dexie("ProjectStorage") as Dexie & {
+	saves: EntityTable<SavedFile, "id">;
+	tempSaves: EntityTable<SavedContent, "id">;
+};
+projectDB.version(1).stores({
+	saves: "++id, mode, robot, date, fileHandle",
+	tempSaves: "++id, mode, robot, date, content, fileSave",
+});

--- a/packages/client/src/lib/state/utils.ts
+++ b/packages/client/src/lib/state/utils.ts
@@ -2,3 +2,13 @@ export function track(state: any) {
 	if (state) {
 	}
 }
+
+export async function findAsync<Type>(
+	arr: Type[],
+	asyncCallback: (item: Type) => Promise<boolean>,
+) {
+	const promises = arr.map(asyncCallback);
+	const results = await Promise.all(promises);
+	const index = results.findIndex((result) => result);
+	return arr[index];
+}

--- a/packages/client/tests/browser_storage.spec.ts
+++ b/packages/client/tests/browser_storage.spec.ts
@@ -23,6 +23,7 @@ test("Saving - Backpack", async ({ page }) => {
 
 	await page.reload();
 
+	await page.getByText("Cancel").click();
 	// Load a different robot type than before, cause why not
 	await selectRobot(page, "Leaphy Starling", "Starling Nano");
 
@@ -49,7 +50,18 @@ test("Saving - Blockly", async ({ page }) => {
 
 	await page.reload();
 
+	await page.getByText("Cancel").click();
 	await selectRobot(page, "Leaphy Original", "Original Uno");
+	await expect(page.getByText("repeat forever")).toBeVisible();
+});
+
+test("Saving - Blockly - Continue working", async ({ page }) => {
+	await selectRobot(page, "Leaphy Original", "Original Uno");
+	await openExample(page, "Blink");
+
+	await page.reload();
+
+	await page.getByText("Continue").and(page.getByRole("button")).click();
 	await expect(page.getByText("repeat forever")).toBeVisible();
 });
 
@@ -63,7 +75,23 @@ test("Saving - C++", async ({ page }) => {
 
 	await page.reload();
 
+	await page.getByText("Cancel").click();
 	await selectRobot(page, "Leaphy C++");
+	await expect(page.getByText("setup")).toBeHidden();
+	await expect(page.getByText("testing")).toBeVisible();
+});
+
+test("Saving - C++ - Continue working", async ({ page }) => {
+	await selectRobot(page, "Leaphy C++");
+	await page.getByText("setup").click();
+	await page.getByLabel("Editor content").fill("testing");
+
+	await expect(page.getByText("setup")).toBeHidden();
+	await expect(page.getByText("testing")).toBeVisible();
+
+	await page.reload();
+
+	await page.getByText("Continue").and(page.getByRole("button")).click();
 	await expect(page.getByText("setup")).toBeHidden();
 	await expect(page.getByText("testing")).toBeVisible();
 });
@@ -75,10 +103,6 @@ test("Saving - New project", async ({ page }) => {
 	// Start a new project, should reset to the default
 	await page.getByRole("button", { name: "My projects" }).click();
 	await page.getByRole("cell", { name: "New" }).click();
-
-	// Open the same editor
-	await page.getByText("Leaphy Original").click();
-	await page.getByText("Original Uno").click();
 
 	// Its a new project, it should not be here!
 	await expect(page.getByText("repeat forever")).toBeHidden();

--- a/packages/client/tests/code_tests.spec.ts
+++ b/packages/client/tests/code_tests.spec.ts
@@ -4,7 +4,6 @@ import {
 	getDownloadContents,
 	goToHomePage,
 	mockShowOpenFilePicker,
-	newProject,
 	selectRobot,
 } from "./utils";
 

--- a/packages/client/tests/language.spec.ts
+++ b/packages/client/tests/language.spec.ts
@@ -9,7 +9,7 @@ test("Language", async ({ page }) => {
 	await page.getByRole("cell", { name: "Language" }).click();
 	await page.getByRole("cell", { name: "Nederlands" }).click();
 	await page.getByRole("button", { name: "Mijn projecten" }).click();
-	await page.getByRole("cell", { name: "Nieuw" }).click();
+	await page.getByRole("cell", { name: "Verander robot" }).click();
 	await selectRobot(page, "Leaphy Original", "Original Nano ESP32");
 	await expect(page.getByText("Lees afstand")).toBeVisible();
 	await expect(page.getByText("Lees anapin")).toBeVisible();

--- a/packages/client/tests/sonar_pins.spec.ts
+++ b/packages/client/tests/sonar_pins.spec.ts
@@ -1,5 +1,5 @@
 import { type Page, expect, test } from "@playwright/test";
-import { goToHomePage, newProject, selectRobot } from "./utils";
+import { goToHomePage, selectRobot, switchRobot } from "./utils";
 
 test.beforeEach(goToHomePage);
 
@@ -24,15 +24,15 @@ test("SonarPins", async ({ page }) => {
 	await selectRobot(page, "Arduino Uno");
 	await test_sonar_pins(page, "7", "8");
 
-	await newProject(page);
+	await switchRobot(page);
 	await selectRobot(page, "Arduino Nano", "Arduino Nano ESP32");
 	await test_sonar_pins(page, "17", "16");
 
-	await newProject(page);
+	await switchRobot(page);
 	await selectRobot(page, "Leaphy Original", "Original Nano");
 	await test_sonar_pins(page, "17", "16");
 
-	await newProject(page);
+	await switchRobot(page);
 	await selectRobot(page, "Leaphy Starling", "Starling Nano");
 	await test_sonar_pins(page, "17", "16");
 });

--- a/packages/client/tests/utils.ts
+++ b/packages/client/tests/utils.ts
@@ -28,9 +28,9 @@ export async function selectRobot(page: Page, tile: string, robot?: string) {
 	}
 }
 
-export async function newProject(page: Page) {
+export async function switchRobot(page: Page) {
 	await page.getByRole("button", { name: "My projects" }).click();
-	await page.getByRole("cell", { name: "New" }).click();
+	await page.getByRole("cell", { name: "Switch robot" }).click();
 }
 
 export async function setupArduino({ page }: PlaywrightTestArgs) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      dexie:
+        specifier: ^4.0.11
+        version: 4.0.11
       esbuild:
         specifier: ^0.25.3
         version: 0.25.3
@@ -2187,6 +2190,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  dexie@4.0.11:
+    resolution: {integrity: sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==}
 
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
@@ -5952,6 +5958,8 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-newline@3.1.0: {}
+
+  dexie@4.0.11: {}
 
   domexception@4.0.0:
     dependencies:


### PR DESCRIPTION
Fix for #234

Previously, the blocks that interface with the I2C channel selection mechanic would default to not generating any code when inserted outside of a select-channel block. Now instead, they default to selecting channel 255 (broadcast). Also took the opportunity to fix a few other outstanding issues and minor problems that became apparent as I was working on this.