### PR TITLE
feat: Micropython dc motor blocks

### DIFF
--- a/packages/blocks/src/generators/python/actuators.ts
+++ b/packages/blocks/src/generators/python/actuators.ts
@@ -129,7 +129,7 @@ function getCodeGenerators(python: MicroPythonGenerator) {
 
 		generator.addDefinition(
 			MotorVariableName,
-			`${MotorVariableName} = DCMotor(direction_pin=\"${direction_pin}\", pwn_pin=\"${pwm_pin}\")`,
+			`${MotorVariableName} = DCMotor(direction_pin=\"${direction_pin}\", pwm_pin=\"${pwm_pin}\")`,
 		);
 
 		return MotorVariableName;

--- a/packages/blocks/src/generators/python/actuators.ts
+++ b/packages/blocks/src/generators/python/actuators.ts
@@ -101,6 +101,41 @@ function getCodeGenerators(python: MicroPythonGenerator) {
 
 		return `SMALL_OLED_${i2c_channel}.show()\n`;
 	};
+
+	python.forBlock.leaphy_original_set_motor = (block, generator) => {
+		const dropdown_Type = block.getFieldValue("MOTOR_TYPE");
+		let speed = python.valueToCode(block, "MOTOR_SPEED", Order.NONE) || "100";
+
+		generator.addImport("leaphymicropython.actuators.dcmotor", "DCMotor");
+
+		let right = dropdown_Type === "10";
+
+		let name = "left";
+		let direction_pin = "D4";
+		let pwm_pin = "D11";
+
+		if (right) {
+			name = "right";
+			direction_pin = "D2";
+			pwm_pin = "D3";
+		}
+
+		const MotorVariableName = python.getVariableName(`motor_${name}`);
+
+		const actual_function_name = generator.provideFunction_("set_motor_speed", [
+			`def ${generator.FUNCTION_NAME_PLACEHOLDER_}(motor, speed):`,
+			"  if speed >= 0:",
+			"    motor.forward(speed)",
+			"  else:",
+			"    motor.backward(-speed)",
+		]);
+		generator.addDefinition(
+			MotorVariableName,
+			`${MotorVariableName} = DCMotor(direction_pin=\"${direction_pin}\", pwn_pin=\"${pwm_pin}\")`,
+		);
+
+		return `${actual_function_name}(${MotorVariableName}, ${speed})\n`;
+	};
 }
 
 export default getCodeGenerators;

--- a/packages/blocks/src/generators/python/actuators.ts
+++ b/packages/blocks/src/generators/python/actuators.ts
@@ -147,7 +147,7 @@ function getCodeGenerators(python: MicroPythonGenerator) {
 	python.forBlock.leaphy_original_move_motors = (block, generator) => {
 		let direction = block.getFieldValue("MOTOR_DIRECTION") as MotorDirection;
 		const speedCode =
-			generator.valueToCode(block, "MOTOR_SPEED", Order.UNARY_SIGN) || "100";
+			generator.valueToCode(block, "MOTOR_SPEED", Order.NONE) || "100";
 		const speedVar = generator.getVariableName("speed");
 
 		let leftMotorName = getDCMotorName(generator, false);

--- a/packages/client/src/lib/domain/blockly/toolbox.ts
+++ b/packages/client/src/lib/domain/blockly/toolbox.ts
@@ -314,7 +314,6 @@ export default [
 						...robotGroups.ALL,
 						-RobotType.L_FLITZ_UNO,
 						-RobotType.L_FLITZ_NANO,
-						RobotType.L_MICROPYTHON,
 					],
 					inputs: {
 						SERVO_ANGLE: number(90),

--- a/packages/client/src/lib/domain/blockly/toolbox.ts
+++ b/packages/client/src/lib/domain/blockly/toolbox.ts
@@ -213,6 +213,7 @@ export default [
 					robots: [
 						...robotGroups.ALL,
 						...robotGroups.L_STARLING_ALL.map((e) => -e),
+						RobotType.L_MICROPYTHON,
 					],
 					type: "leaphy_original_set_motor",
 					inputs: {
@@ -312,6 +313,7 @@ export default [
 						...robotGroups.ALL,
 						-RobotType.L_FLITZ_UNO,
 						-RobotType.L_FLITZ_NANO,
+						RobotType.L_MICROPYTHON,
 					],
 					inputs: {
 						SERVO_ANGLE: number(90),

--- a/packages/client/src/lib/domain/blockly/toolbox.ts
+++ b/packages/client/src/lib/domain/blockly/toolbox.ts
@@ -224,6 +224,7 @@ export default [
 					robots: [
 						...robotGroups.ALL,
 						...robotGroups.L_STARLING_ALL.map((e) => -e),
+						RobotType.L_MICROPYTHON,
 					],
 					type: "leaphy_original_move_motors",
 					inputs: {


### PR DESCRIPTION
Adds 2 blocks for the MicroPython editor to control DC motors

<img width="331" height="227" alt="image" src="https://github.com/user-attachments/assets/5db07d63-ae32-4e87-8458-8739122eb716" />
