### PR TITLE
Fix: Add scrollbar for large compile errors

### DIFF
--- a/packages/client/src/lib/components/core/popups/popups/Uploader.svelte
+++ b/packages/client/src/lib/components/core/popups/popups/Uploader.svelte
@@ -204,6 +204,7 @@ async function connectUSB() {
         background: var(--secondary);
         border-radius: 5px;
         padding: 10px;
+        overflow: auto;
         color: red;
     }
 </style>


### PR DESCRIPTION
closes #255

Now when a absurdly long compile error happens it looks like this:
<img width="659" height="865" alt="image" src="https://github.com/user-attachments/assets/bfd48858-5c15-4318-b131-f1d9b366e2de" />
