### PR TITLE
fix: ignore missing pins when connecting a circuit

### DIFF
--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -87,9 +87,8 @@ class VisibleComponent {
 
 	port(port: string): VisiblePort {
 		if (!this.component.mappings[port]) {
-			throw Error(
-				`Port ${port} not found on ${this.id} (${this.component.schema})`,
-			);
+			console.warn(`Port ${port} does not exist on component ${this.id}`);
+			return { component: this.id, port: "" };
 		}
 
 		return {


### PR DESCRIPTION
This is an ugly workaround, should be fixed by disabling circuit generation per robot type (or something)