### PR TITLE
fix: time delay block now respects period selection in micropython

### DIFF
--- a/packages/blocks/src/generators/python/situation.ts
+++ b/packages/blocks/src/generators/python/situation.ts
@@ -8,16 +8,22 @@ import type { MicroPythonGenerator } from "../python";
 
 function getCodeGenerators(python: MicroPythonGenerator) {
 	python.forBlock.time_delay = (block, generator) => {
-		//Micropython recommends the utime module instead of the default time-keeping module.
-		//Said module offers both a sleep(seconds) function and a sleep_ms(ms) function, along
-		//with a warning that some Micropython ports "may not accept [a] floating point argument
-		// [for the sleep function.]"
-
+		const unit = block.getFieldValue("UNIT") || "s";
 		const delay = generator.valueToCode(block, "DELAY_TIME_MILI", Order.NONE);
 
-		generator.addImport("utime", "sleep_ms");
-
-		return `sleep_ms(${delay})\n`;
+		if (unit === "s") {
+			generator.addImport("utime", "sleep");
+			return `sleep(${delay})\n`;
+		}
+		if (unit === "ms") {
+			generator.addImport("utime", "sleep_ms");
+			return `sleep_ms(${delay})\n`;
+		}
+		if (unit === "μs") {
+			generator.addImport("utime", "sleep_us");
+			return `sleep_us(${delay})\n`;
+		}
+		return "#Could not set up sleep call.\n";
 	};
 
 	//The default python generator does not innately support infinite loops, surprisingly.


### PR DESCRIPTION
Addressing issue #402, this pull request makes the time delay block import and use the appropriate sleep function.